### PR TITLE
Bump to 1.1.0 to add USB.Device.getHost()

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2017 Electric Imp
+Copyright 2017-19 Electric Imp
 
 SPDX-License-Identifier: MIT
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# USB Drivers Framework 1.0.1 #
+# USB Drivers Framework 1.1.0 #
 
 The USB Drivers Framework is designed to simplify and standardize USB driver development and integration with Electric Imp device code. Its primary audience comprises:
 

--- a/USB.device.lib.nut
+++ b/USB.device.lib.nut
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright 2017 Electric Imp
+// Copyright 2017-19 Electric Imp
 //
 // SPDX-License-Identifier: MIT
 //
@@ -102,7 +102,7 @@ const USB_DEVICE_STATE_DISCONNECTED         = "disconnected";
 // Not intended to use by any developers.
 USB <- {
 
-    VERSION = "1.0.1",
+    VERSION = "1.1.0",
 
     // Debug flag
     debug = true,
@@ -495,6 +495,13 @@ USB <- {
                     }
                 }
             }
+        }
+
+        // Returns the device's USB host.
+        // Returns:
+        //      the host
+        function getHost() {
+            return _host;
         }
 
         // Returns device descriptor

--- a/docs/ApplicationDevelopmentGuide.md
+++ b/docs/ApplicationDevelopmentGuide.md
@@ -6,14 +6,14 @@ Before you use a driver, please read its documentation carefully to fully unders
 
 ## Including The USB Drivers Framework Library And Device Drivers ##
 
-To include the USB Drivers Framework Library in your application, add `#require "USB.device.lib.nut:1.0.1"` to the top of your device code.
+To include the USB Drivers Framework Library in your application, add `#require "USB.device.lib.nut:1.1.0"` to the top of your device code.
 
 By default the base USB Drivers Framework Library does not itself provide any device drivers. Application developers will therefore need to include the base Drivers Framework Library as well as any device drivers they need in their code.
 
 At this time there are no Electric Imp supported USB Device Driver Libraries. Statements to include specific USB device drivers and other, related libraries should be placed after the USB Drivers Framework Library import statement, but before any application code. See the following examples for how to include USB drivers in your code:
 
 ```squirrel
-#require "USB.device.lib.nut:1.0.1"
+#require "USB.device.lib.nut:1.1.0"
 
 class BootKeyboardDriver extends USB.Driver {
   // Your driver code goes here
@@ -23,7 +23,7 @@ class BootKeyboardDriver extends USB.Driver {
 Or, if you are using Builder or some other tool instead of the impCentral IDE, you may load the driver code using Builder's include statement:
 
 ```squirrel
-#require "USB.device.lib.nut:1.0.1"
+#require "USB.device.lib.nut:1.1.0"
 
 @include "github:electricimp/usb/drivers/BootKeyboard/BootKeyboard.device.lib.nut"
 ```
@@ -39,7 +39,7 @@ The following code example shows how to initialize the USB Drivers Framework wit
 **Note** The code below runs on an imp005-based board and should be built with the [Builder](https://github.com/electricimp/builder) preprocessor.
 
 ```squirrel
-#require "USB.device.lib.nut:1.0.1"
+#require "USB.device.lib.nut:1.1.0"
 
 // Include FT232RLFtdiUsbDriver class
 @include "github:electricimp/usb/drivers/FT232RL_FTDI_USB_Driver/FT232RLFtdiUsbDriver.device.lib.nut"
@@ -74,7 +74,7 @@ The final line shows how to register a driver-state listener function by calling
 It is possible to register any number of drivers with the USB Drivers Framework: just add further device-driver class references to the array parameter in the [USB.Host](DriverDevelopmentGuide.md#usbhost-class-usage) constructor:
 
 ```squirrel
-#require "USB.device.lib.nut:1.0.1"
+#require "USB.device.lib.nut:1.1.0"
 
 #require "ACustomDriver2.nut:1.2.0"
 #require "ACustomDriver1.nut:1.0.0"
@@ -114,7 +114,7 @@ The [USB.Device](DriverDevelopmentGuide.md#usbdevice-class-usage) class provides
 The following example code shows how to retrieve the endpoint 0 to then use it for device configuration:
 
 ```squirrel
-#require "USB.device.lib.nut:1.0.1"
+#require "USB.device.lib.nut:1.1.0"
 
 const VID = 0x413C;
 const PID = 0x2107;
@@ -166,7 +166,7 @@ It is not necessary to configure [*setDriverListener()*](DriverDevelopmentGuide.
 The following example shows *reset()* being used:
 
 ```squirrel
-#require "USB.device.lib.nut:1.0.1"
+#require "USB.device.lib.nut:1.1.0"
 
 // Custom driver class
 class MyCustomDriver extends USB.Driver {

--- a/docs/DriverDevelopmentGuide.md
+++ b/docs/DriverDevelopmentGuide.md
@@ -300,7 +300,7 @@ It should be instantiated only once per physical port for any application. There
 #### Example ####
 
 ```squirrel
-#require "USB.device.lib.nut:1.0.1"
+#require "USB.device.lib.nut:1.1.0"
 
 class MyCustomDriver1 extends USB.Driver {
   ...
@@ -483,6 +483,14 @@ This method returns a proxy for the device’s Control Endpoint 0. The endpoint 
 #### Return Value ####
 
 [USB.ControlEndpoint](#usbcontrolendpoint-class-usage) &mdash; the zero endpoint.
+
+### getHost() ###
+
+This method returns a reference to the parent USB host.
+
+#### Return Value ####
+
+[USB.Host](#usbhost-class-usage) &mdash; the host to which the device is connected.
 
 ## USB.ControlEndpoint Class Usage ##
 

--- a/drivers/BootKeyboard/README.md
+++ b/drivers/BootKeyboard/README.md
@@ -8,10 +8,10 @@ This class is an example of how to extend the USB Devices Framework [USB.Driver]
 
 The driver depends on constants and classes within the [USB Drivers Framework](../../docs/DriverDevelopmentGuide.md#usb-drivers-framework-api-specification).
 
-To add the Boot Keyboard driver into your project, add `#require "USB.device.lib.nut:1.0.1"` top of you application code and then either include the Boot Keyboard driver in your application by pasting its code into yours or by using [Builder's @include statement](https://github.com/electricimp/builder#include):
+To add the Boot Keyboard driver into your project, add `#require "USB.device.lib.nut:1.1.0"` top of you application code and then either include the Boot Keyboard driver in your application by pasting its code into yours or by using [Builder's @include statement](https://github.com/electricimp/builder#include):
 
 ```squirrel
-#require "USB.device.lib.nut:1.0.1"
+#require "USB.device.lib.nut:1.1.0"
 @include "github:electricimp/usb/drivers/BootKeyboard/BootKeyboard.device.lib.nut"
 ```
 
@@ -110,7 +110,7 @@ Nothing, or an error description if an error occurred.
 #require "JSONEncoder.class.nut:1.0.0"
 
 // Include the USB framework and the BootKeyboard library
-#require "USB.device.lib.nut:1.0.1"
+#require "USB.device.lib.nut:1.1.0"
 @include "github:electricimp/usb/drivers/BootKeyboard/BootKeyboard.device.lib.nut"
 
 // Debug print setup

--- a/drivers/FT232RL_FTDI_USB_Driver/README.md
+++ b/drivers/FT232RL_FTDI_USB_Driver/README.md
@@ -11,10 +11,10 @@ This example shows you how to implement and use the FT232RL USB driver. It inclu
 
 The driver depends on constants and classes within the [USB Drivers Framework](../../docs/DriverDevelopmentGuide.md#usb-drivers-framework-api-specification).
 
-To add the FT232RL FTDI USB Device Driver into your project, add `#require "USB.device.lib.nut:1.0.1"` top of your application code and then either include the FT232RLFtdiUsbDriver in you application by pasting its code into yours or by using [Builder's @include statement](https://github.com/electricimp/builder#include):
+To add the FT232RL FTDI USB Device Driver into your project, add `#require "USB.device.lib.nut:1.1.0"` top of your application code and then either include the FT232RLFtdiUsbDriver in you application by pasting its code into yours or by using [Builder's @include statement](https://github.com/electricimp/builder#include):
 
 ```squirrel
-#require "USB.device.lib.nut:1.0.1"
+#require "USB.device.lib.nut:1.1.0"
 @include "github:electricimp/usb/drivers/FT232RL_FTDI_USB_Driver/FT232RLFtdiUsbDriver.device.lib.nut"
 ```
 

--- a/drivers/GenericHID_Driver/README.md
+++ b/drivers/GenericHID_Driver/README.md
@@ -10,10 +10,10 @@ Please familiarize yourself with the [Device Class Definition for Human Interfac
 
 The driver depends on constants and classes within the [USB Drivers Framework](../../docs/DriverDevelopmentGuide.md#usb-drivers-framework-api-specification).
 
-To add the Generic HID driver to your project, add `#require "USB.device.lib.nut:1.0.1"` top of your application code and then either include the Generic HID driver in your application by pasting its code into yours or by using [Builder's @include statement](https://github.com/electricimp/builder#include):
+To add the Generic HID driver to your project, add `#require "USB.device.lib.nut:1.1.0"` top of your application code and then either include the Generic HID driver in your application by pasting its code into yours or by using [Builder's @include statement](https://github.com/electricimp/builder#include):
 
 ```squirrel
-#require "USB.device.lib.nut:1.0.1"
+#require "USB.device.lib.nut:1.1.0"
 @include "github:electricimp/usb/drivers/GenericHID_Driver/USB.HID.device.lib.nut"
 ```
 

--- a/drivers/HIDKeyboard/README.md
+++ b/drivers/HIDKeyboard/README.md
@@ -8,10 +8,10 @@ This driver is an example of an HID [Driver](../GenericHID_Driver/README.md) app
 
 The driver depends on constants and classes within the [USB Drivers Framework](../../docs/DriverDevelopmentGuide.md#usb-drivers-framework-api-specification).
 
-To add the HID Keyboard driver to your project, add `#require "USB.device.lib.nut:1.0.1"` top of you application code and then either include the HID Keyboard driver in your application by pasting its code into yours or by using [Builder's @include statement](https://github.com/electricimp/builder#include):
+To add the HID Keyboard driver to your project, add `#require "USB.device.lib.nut:1.1.0"` top of you application code and then either include the HID Keyboard driver in your application by pasting its code into yours or by using [Builder's @include statement](https://github.com/electricimp/builder#include):
 
 ```squirrel
-#require "USB.device.lib.nut:1.0.1"
+#require "USB.device.lib.nut:1.1.0"
 
 @include "github:electricimp/usb/drivers/GenericHID_Driver/USB.HID.device.lib.nut"
 @include "github:electricimp/usb/drivers/HIDKeyboard/HIDKeyboard.device.lib.nut"
@@ -106,7 +106,7 @@ It returns the converted code values
 **Note** The code below should be built with the [Builder](https://github.com/electricimp/builder) preprocessor.
 
 ```squirrel
-#require "USB.device.lib.nut:1.0.1"
+#require "USB.device.lib.nut:1.1.0"
 #require "USB.HID.device.lib.nut:1.0.0"
 @include "github:electricimp/usb/drivers/HIDKeyboard/HIDKeyboard.device.lib.nut"
 @include "github:electricimp/usb/drivers/HIDKeyboard/US-ASCII.table.nut"


### PR DESCRIPTION
I've added a very simple method *getHost()* to the USB framework in order to 'legalize' an access of the private __host_ property Hugo makes in his hub code. This way, we make it part of the public API, and it's a very straightforward update.