### PR TITLE
Fix Device class members initial values

### DIFF
--- a/USB.device.lib.nut
+++ b/USB.device.lib.nut
@@ -399,10 +399,10 @@ USB <- {
 
         // A list of drivers assigned to this device
         // There can be more than one driver for composite device
-        _driverInstances = [];
+        _driverInstances = null;
 
         // Endpoints instances for this device. Required for quick search from transfer event processor
-        _endpoints = {};
+        _endpoints = null;
 
         // Device speed
         _speed = null;
@@ -429,6 +429,7 @@ USB <- {
             local conf = deviceDescriptor.configurations[0];
             _interfaces = conf.interfaces;
             _driverInstances = [];
+            _endpoints = {};
 
             local ep0 = USB.ControlEndpoint(this, 0, _desc["maxpacketsize0"]);
             _endpoints[0] <- ep0;


### PR DESCRIPTION
Initializing members to tables in class definition makes them static, that is not what was meant